### PR TITLE
Hide second div on big screens

### DIFF
--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -258,7 +258,7 @@ const Home: NextPage = () => {
             </div>
           </div>
 
-          <div className="p-10 md:p-20 flex justify-center items-center">
+          <div className="p-10 md:p-20 flex md:hidden justify-center items-center">
             <div>
               <h2 className="font-bold text-3xl text-white mb-5 opacity-20">
                 Once per day


### PR DESCRIPTION
### tl;dr

- [x] Hides the second copy of the drop on big screens